### PR TITLE
feat: add API cohort 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,47 @@
 README for Cohort API for learners
 
-Cohort API used to get information about the student's cohort. To use it,
-just include this xblock from Studio into your course and after loading it will emit an
-event with the information about the cohort.
+Cohort API used to get information about the student's cohort.
 
-To get it, you will have to include in your component the following script:
+Intructions on how to use:
 
-document.addEventListener("cohort_obtained", (event) => {
-    userCohort = event.detail.cohort_name
-});
+1. Include this component in your course. You can include it in any course unit.
+2. Save the Block ID.
+3. Using it, you can reconstruct the handler URL used to get cohort information. You can follow this pattern:
+   currentDomain/courses/courseID/xblock/xblockID/handler/get_user_cohort
+4. Make a POST request to the handler as follows (using javascript):
 
-For now, we are only sending the name of the cohort.
+.. code-block:: javascript
+
+    function getUsersCohort(){
+        var headers = {
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        "x-csrftoken": getCSRFToken(),
+
+        }
+
+        return fetch(
+        `domain/courses/${courseIdSafe}/xblock/${xblockIDSafe}/handler/get_user_cohort`,
+        {
+            method: "POST",
+            credentials: 'include',
+            body: JSON.stringify({}),
+            headers: headers
+        },
+        )
+        .then(function (response) {
+            if (!response.ok) throw Error(response.statusText);
+            return response.json();
+        })
+            .then(function (response) {
+            return response;
+        })
+            .catch(function (error) {
+            console.warn(error);
+        });
+    }
+
+
+Then you'll get the cohort information. For now, we are only sending the name of the cohort.
 
 Testing with Docker
 ====================

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,16 @@
 README for Cohort API for learners
 
+Cohort API used to get information about the student's cohort. To use it,
+just include this xblock from Studio into your course and after loading it will emit an
+event with the information about the cohort.
+
+To get it, you will have to include in your component the following script:
+
+document.addEventListener("cohort_obtained", (event) => {
+    userCohort = event.detail.cohort_name
+});
+
+For now, we are only sending the name of the cohort.
 
 Testing with Docker
 ====================

--- a/cohort_api_xblock/cohort_api_xblock.py
+++ b/cohort_api_xblock/cohort_api_xblock.py
@@ -1,4 +1,7 @@
-"""TO-DO: Write a description of what this XBlock is."""
+"""
+Cohort API used to get information about the student's cohort. To use it, just include this xblock at some place in the course.
+For now, this returns the name of the student's cohort.
+"""
 
 import pkg_resources
 
@@ -27,12 +30,16 @@ class CohortAPIXblock(XBlock):
         data = pkg_resources.resource_string(__name__, path)
         return data.decode("utf8")
 
-    # TO-DO: change this view to display your data your own way.
     def student_view(self, context=None):
         """
         The primary view of the CohortAPIXblock, shown to students
         when viewing courses.
         """
+        in_studio_runtime = hasattr(self.xmodule_runtime, 'is_author_mode')
+
+        if in_studio_runtime:
+            return self.studio_view(context)
+
         html = self.resource_string("static/html/cohort_api_xblock.html")
         frag = Fragment(html.format(self=self))
         frag.add_css(self.resource_string("static/css/cohort_api_xblock.css"))
@@ -61,7 +68,7 @@ class CohortAPIXblock(XBlock):
         """
         is_studio = hasattr(self.xmodule_runtime, "is_author_mode")  # pylint: disable=no-member
 
-        if is_studio:
+        if is_studio or self.xmodule_runtime.__class__.__name__ == "StudioEditModuleRuntime":
             return {}
 
         current_anonymous_student_id = self.runtime.anonymous_student_id

--- a/cohort_api_xblock/cohort_api_xblock.py
+++ b/cohort_api_xblock/cohort_api_xblock.py
@@ -4,23 +4,22 @@ import pkg_resources
 
 from django.utils import translation
 from xblock.core import XBlock
-from xblock.fields import Scope, Integer
+from xblock.fields import Scope, String
 from xblock.fragment import Fragment
 from xblockutils.resources import ResourceLoader
 
+from openedx.core.djangoapps.course_groups.cohorts import get_cohort
+from opaque_keys.edx.keys import CourseKey
 
 class CohortAPIXblock(XBlock):
     """
-    TO-DO: document what your XBlock does.
+    Xblock used to get data about students cohorts.
     """
 
-    # Fields are defined on the class.  You can access them in your code as
-    # self.<fieldname>.
-
-    # TO-DO: delete count, and define your own fields.
-    count = Integer(
-        default=0, scope=Scope.user_state,
-        help="A simple counter, to show something happening",
+    cohort_name = String(
+        default="Default cohort name",
+        scope=Scope.user_state,
+        help="Cohort name where the user belongs.",
     )
 
     def resource_string(self, path):
@@ -37,31 +36,43 @@ class CohortAPIXblock(XBlock):
         html = self.resource_string("static/html/cohort_api_xblock.html")
         frag = Fragment(html.format(self=self))
         frag.add_css(self.resource_string("static/css/cohort_api_xblock.css"))
-
-        # Add i18n js
-        statici18n_js_url = self._get_statici18n_js_url()
-        if statici18n_js_url:
-            frag.add_javascript_url(self.runtime.local_resource_url(self, statici18n_js_url))
-
         frag.add_javascript(self.resource_string("static/js/src/cohort_api_xblock.js"))
         frag.initialize_js('CohortAPIXblock')
         return frag
 
-    # TO-DO: change this handler to perform your own actions.  You may need more
-    # than one handler, or you may not need any handlers at all.
+    def studio_view(self, context=None):
+        """
+        Returns author view fragment on Studio.
+        Should display an example on how to use this xblock.
+        """
+        # pylint: disable=unused-argument, no-self-use
+        html = self.resource_string("static/html/cohort_api_xblock_author.html")
+        frag = Fragment(html.format(self=self))
+        frag.add_css(self.resource_string("static/css/cohort_api_xblock.css"))
+        frag.add_javascript(self.resource_string("static/js/src/cohort_api_xblock.js"))
+        frag.initialize_js('CohortAPIXblock')
+        return frag
+
     @XBlock.json_handler
-    def increment_count(self, data, suffix=''):
+    def get_user_cohort(self, data, suffix=''):
         """
-        An example handler, which increments the data.
+        Handler used to retrieve information about the students cohort, it uses the course that
+        includes this component.
         """
-        # Just to show data coming in...
-        assert data['hello'] == 'world'
+        is_studio = hasattr(self.xmodule_runtime, "is_author_mode")  # pylint: disable=no-member
 
-        self.count += 1
-        return {"count": self.count}
+        if is_studio:
+            return {}
 
-    # TO-DO: change this to create the scenarios you'd like to see in the
-    # workbench while developing your XBlock.
+        current_anonymous_student_id = self.runtime.anonymous_student_id
+        user = self.runtime.get_real_user(current_anonymous_student_id)
+        course_id_str = str(self.runtime.course_id)
+
+        course_key = CourseKey.from_string(course_id_str)
+        cohort = get_cohort(user, course_key, assign=False, use_cached=True)
+
+        return {"cohort_name": cohort.name}
+
     @staticmethod
     def workbench_scenarios():
         """A canned scenario for display in the workbench."""
@@ -77,28 +88,3 @@ class CohortAPIXblock(XBlock):
                 </vertical_demo>
              """),
         ]
-
-    @staticmethod
-    def _get_statici18n_js_url():
-        """
-        Returns the Javascript translation file for the currently selected language, if any.
-        Defaults to English if available.
-        """
-        locale_code = translation.get_language()
-        if locale_code is None:
-            return None
-        text_js = 'public/js/translations/{locale_code}/text.js'
-        lang_code = locale_code.split('-')[0]
-        for code in (locale_code, lang_code, 'en'):
-            loader = ResourceLoader(__name__)
-            if pkg_resources.resource_exists(
-                    loader.module_name, text_js.format(locale_code=code)):
-                return text_js.format(locale_code=code)
-        return None
-
-    @staticmethod
-    def get_dummy():
-        """
-        Dummy method to generate initial i18n
-        """
-        return translation.gettext_noop('Dummy')

--- a/cohort_api_xblock/cohort_api_xblock.py
+++ b/cohort_api_xblock/cohort_api_xblock.py
@@ -71,6 +71,9 @@ class CohortAPIXblock(XBlock):
         course_key = CourseKey.from_string(course_id_str)
         cohort = get_cohort(user, course_key, assign=False, use_cached=True)
 
+        if not cohort:
+            return {}
+
         return {"cohort_name": cohort.name}
 
     @staticmethod

--- a/cohort_api_xblock/static/css/cohort_api_xblock.css
+++ b/cohort_api_xblock/static/css/cohort_api_xblock.css
@@ -7,3 +7,11 @@
 .cohort_api_xblock_block p {
     cursor: pointer;
 }
+
+/* The alert message box */
+.alert {
+    padding: 20px;
+    background-color: #f44336; /* Red */
+    color: white;
+    margin-bottom: 15px;
+  }

--- a/cohort_api_xblock/static/html/cohort_api_xblock.html
+++ b/cohort_api_xblock/static/html/cohort_api_xblock.html
@@ -1,5 +1,0 @@
-<div class="cohort_api_xblock_block">
-<p>CohortAPIXblock: count is now
-    <span class='count'>{self.count}</span> (click me to increment).
-</p>
-</div>

--- a/cohort_api_xblock/static/html/cohort_api_xblock_author.html
+++ b/cohort_api_xblock/static/html/cohort_api_xblock_author.html
@@ -1,15 +1,18 @@
 <div class="cohort_api_xblock_block">
+  <div class="alert">
+    if you do not know what this component is for, please do not remove it. Contact the course administrator.
+  </div>
   <p>
     Cohort API used to get information about the student's cohort. To use it,
-    just include this xblock in the course and after loading it will emit an
-    event with the information about the cohort.
-
-    To get it, you will have to include in your component the following script:
-
-    document.addEventListener("cohort_obtained", (event) => {
-        userCohort = event.detail.cohort_name
-    });
-
-    For now, we are only sending the name of the cohort.
+    just include this xblock in the course.
+    Instructions:
+    <ol>
+        <li>1. Include this component in your course. You can include it in any course unit.</li>
+        <li>2. Save the Block ID.</li>
+        <li>3. To use in conjunction with JSinput for video-sessions please go to Studio edit the
+            JSinput and add in BlockID the ID of the block you just created.
+        </li>
+    </ol>
+    If you're not using this component in conjunction with JSinput for video sessions, contact the course administrator.
   </p>
 </div>

--- a/cohort_api_xblock/static/html/cohort_api_xblock_author.html
+++ b/cohort_api_xblock/static/html/cohort_api_xblock_author.html
@@ -1,0 +1,15 @@
+<div class="cohort_api_xblock_block">
+  <p>
+    Cohort API used to get information about the student's cohort. To use it,
+    just include this xblock in the course and after loading it will emit an
+    event with the information about the cohort.
+
+    To get it, you will have to include in your component the following script:
+
+    document.addEventListener("cohort_obtained", (event) => {
+        userCohort = event.detail.cohort_name
+    });
+
+    For now, we are only sending the name of the cohort.
+  </p>
+</div>

--- a/cohort_api_xblock/static/js/src/cohort_api_xblock.js
+++ b/cohort_api_xblock/static/js/src/cohort_api_xblock.js
@@ -1,36 +1,4 @@
-/* Javascript for CohortAPIXblock.
-
-   After successfully calling the JSONHandler `get_user_cohort` an event is emitted with
-   the cohort information.
-
-   For now, we provide:
-    - cohort_name
-
-   This can be accessed by listening to the event `cohort_obtained`.
-
-*/
+/* Javascript for CohortAPIXblock. */
 function CohortAPIXblock(runtime, element) {
-  function successHandler(result) {
-    var detail = result.cohort_name
-      ? {
-          cohort_name: result.cohort_name,
-        }
-      : {};
-    var event = new CustomEvent("cohort_obtained", {
-      detail: detail,
-    });
-    document.dispatchEvent(event);
-  }
 
-  var handlerUrl = runtime.handlerUrl(element, "get_user_cohort");
-
-  /* Here's where you'd do things on page load. */
-  $(function ($) {
-    $.ajax({
-      type: "POST",
-      url: handlerUrl,
-      data: JSON.stringify({}),
-      success: successHandler,
-    });
-  });
 }

--- a/cohort_api_xblock/static/js/src/cohort_api_xblock.js
+++ b/cohort_api_xblock/static/js/src/cohort_api_xblock.js
@@ -1,28 +1,36 @@
-/* Javascript for CohortAPIXblock. */
+/* Javascript for CohortAPIXblock.
+
+   After successfully calling the JSONHandler `get_user_cohort` an event is emitted with
+   the cohort information.
+
+   For now, we provide:
+    - cohort_name
+
+   This can be accessed by listening to the event `cohort_obtained`.
+
+*/
 function CohortAPIXblock(runtime, element) {
-
-    function updateCount(result) {
-        $('.count', element).text(result.count);
-    }
-
-    var handlerUrl = runtime.handlerUrl(element, 'increment_count');
-
-    $('p', element).click(function(eventObject) {
-        $.ajax({
-            type: "POST",
-            url: handlerUrl,
-            data: JSON.stringify({"hello": "world"}),
-            success: updateCount
-        });
+  function successHandler(result) {
+    var detail = result.cohort_name
+      ? {
+          cohort_name: result.cohort_name,
+        }
+      : {};
+    var event = new CustomEvent("cohort_obtained", {
+      detail: detail,
     });
+    document.dispatchEvent(event);
+  }
 
-    $(function ($) {
-        /*
-        Use `gettext` provided by django-statici18n for static translations
+  var handlerUrl = runtime.handlerUrl(element, "get_user_cohort");
 
-        var gettext = CohortAPIXblocki18n.gettext;
-        */
-
-        /* Here's where you'd do things on page load. */
+  /* Here's where you'd do things on page load. */
+  $(function ($) {
+    $.ajax({
+      type: "POST",
+      url: handlerUrl,
+      data: JSON.stringify({}),
+      success: successHandler,
     });
+  });
 }

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     entry_points={
         'xblock.v1': [
-            'CohortAPIXblock = cohort_api_xblock:CohortAPIXblock',
+            'cohort-api = cohort_api_xblock:CohortAPIXblock',
         ]
     },
     package_data=package_data("cohort_api_xblock", ["static", "public"]),


### PR DESCRIPTION
This PR adds a mechanism for getting cohort information using Xblock Architecture

Taken from README.rst

Cohort API used to get information about the student's cohort.

Intructions on how to use:

1. Include this component in your course. You can include it in any course unit.
2. Save the Block ID.
3. Using it, you can reconstruct the handler URL used to get cohort information. You can follow this pattern:
   currentDomain/courses/courseID/xblock/xblockID/handler/get_user_cohort
4. Make a POST request to the handler as follows (using javascript):

```
    var headers = {
    "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
    "x-csrftoken": getCSRFToken(),

    }

    return fetch(
    `domain/courses/${courseIdSafe}/xblock/${xblockIDSafe}/handler/get_user_cohort`,
    {
        method: "POST",
        credentials: 'include',
        body: JSON.stringify({}),
        headers: headers
    },
    )
    .then(function (response) {
        if (!response.ok) throw Error(response.statusText);
        return response.json();
    })
        .then(function (response) {
        return response;
    })
        .catch(function (error) {
        console.warn(error);
    });
    }
```

Then you'll get the cohort information. For now, we are only sending the name of the cohort.
